### PR TITLE
Resolve version conflict of Sparrow

### DIFF
--- a/docker-setup/setup_Sparrow.sh
+++ b/docker-setup/setup_Sparrow.sh
@@ -9,6 +9,8 @@ apt-get update
 apt-get install -y opam libclang-cpp12-dev libgmp-dev libclang-12-dev llvm-12-dev libmpfr-dev
 
 sed -i '/^opam init/ s/$/ --disable-sandboxing/' build.sh
+sed -i 's/opam install apron clangml/opam install conf-libclang.12 apron clangml/' build.sh
+sed -i 's|opam pin add cil https://github.com/prosyslab/cil.git -n|opam pin add cil https://github.com/prosyslab/cil.git#8e87fe45 -n|' build.sh
 ./build.sh
 opam install ppx_compare yojson ocamlgraph memtrace lymp clangml conf-libclang.12 batteries apron conf-mpfr cil linenoise claml
 


### PR DESCRIPTION
Hello,

I encountered an error while building the provided Dockerfile, especially when executing the code: `RUN /setup_Sparrow.sh` (line 107).

There were two issues.

---

1. Missing dependencies

When installing `clangml` via `/sparrow/build.sh`, opam automatically installs `conf-libclang.15`.
However, the required dependencies seem to be version `12`, not `15`.

- Workaround

By patching `/sparrow/build.sh` to install `conf-libclang.12` before `clangml`, opam no longer installs `conf-libclang.15`.

---

2. Opam cannot follow updated Cil

When installing `cil` with `opam install <some programs> cil` at docker-setup/`setup_Sparrow.sh`, an error occured as follows:

```
Sorry, no solution found: there seems to be a problem with your request.
```

- Workaround

Similarly, I resolved this issue by patching the `/sparrow/build.sh` file to pin a specific commit of `cil`.
By forcing the hash `8e87fe45`, which matches the Docker image uploaded, the error was resolved.

---

There may be a better way to fix these two issues, but hope this helps! :)